### PR TITLE
Fix JSON issue when content start with a list

### DIFF
--- a/niet/__init__.py
+++ b/niet/__init__.py
@@ -136,7 +136,7 @@ def data_parser(dataset):
             print(str(err))
         except yaml.parser.ParserError as err:
             print(str(err))
-    if not isinstance(result, dict):
+    if not isinstance(result, (list, dict)):
         print("Invalid file. Only support valid json and yaml input")
         sys.exit(1)
     return result, in_format


### PR DESCRIPTION
When JSON content start with a list niet can load content
but a condition in the code expect the content start with
a dict so niet believe the loading have failed and exit with
in error.

This change simply transform the condition to check if have dict or list