### PR TITLE
Introduce eval output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,10 @@ script:
 - niet --format json project.list tests/samples/sample.yaml
 - niet project.'"test-dash"' tests/samples/sample.yaml
 - niet project.'"test-dash"' tests/samples/sample.json
+- niet project.'"test-dash"' tests/samples/sample.json -f eval
+- niet project.list tests/samples/sample.json -f eval
+- niet project tests/samples/sample.json -f eval
+- eval $(niet project tests/samples/sample.json -f eval); test "${project__foo}" = "bar"
 deploy:
   - provider: pypi
     user: 4383

--- a/README.md
+++ b/README.md
@@ -339,6 +339,43 @@ while read value: do
     echo $value
 done < $(niet --format newline project.list your-file.json)
 ```
+
+#### eval
+
+Eval output format allow you to eval output string to initialize shell
+variable generated from your JSON/YAML content.
+
+You can intialize shell variables from your entire content, example:
+
+```sh
+$ echo '{"foo-biz": "bar", "fizz": {"buzz": ["zero", "one", "two", "three"]}}' | niet -f eval .
+ foo_biz="bar";fizz__buzz=( zero one two three )
+$ eval $(echo '{"foo-biz": "bar", "fizz": {"buzz": ["zero", "one", "two", "three"]}}' | niet -f eval .)
+$ echo ${foo_biz}
+bar
+$ echo ${fizz__buzz}
+zero one two three
+$ eval $(echo '{"foo-biz": "bar", "fizz": {"buzz": ["zero", "one", "two", "three"]}}' | niet -f eval '"foo-biz"'); echo ${foo_biz}
+bar
+$ echo '{"foo-biz": "bar", "fizz": {"buzz": ["zero", "one", "two", "three"]}}' | niet -f eval fizz.buzz
+fizz_buzz=( zero one two three );
+```
+
+Parent elements are separated by `__` by example the `fizz.buzz` element
+will be represented by a variable named `fizz__buzz`. You need to consider
+that when you call your expected variables.
+
+Also you can initialize some shell array from your content and loop over in
+a shell maner:
+
+```sh
+$ eval $(echo '{"foo-biz": "bar", "fizz": {"buzz": ["zero", "one", "two", "three"]}}' | niet -f eval fizz.buzz)
+$ for el in ${fizz_buzz}; do echo $el; done
+zero
+one
+two
+three
+```
  
 #### yaml
 Yaml output format force output to be in YAML regardless the input file format.

--- a/niet/output.py
+++ b/niet/output.py
@@ -1,0 +1,84 @@
+import json
+import os
+
+import yaml
+
+IFS = os.getenv('IFS', ' ')
+
+
+# Output functions
+def print_squote(res):
+    if isinstance(res, list):
+        res = IFS.join(["'{}'".format(el) for el in res])
+    elif (isinstance(res, str) or isinstance(res, int)):
+        res = "".join("'{}'".format(res))
+    return res
+
+
+def print_dquote(res):
+    if isinstance(res, list):
+        res = IFS.join(["\"{}\"".format(el) for el in res])
+    elif (isinstance(res, str) or isinstance(res, int)):
+        res = "".join("\"{}\"".format(res))
+    return res
+
+
+def print_ifs(res):
+    if isinstance(res, list):
+        res = IFS.join(["{}".format(el) for el in res])
+    return res
+
+
+def print_newline(res):
+    if isinstance(res, list):
+        try:
+            return '\n'.join(res)
+        except TypeError:
+            result = []
+            for el in res:
+                result.append(yaml.dump(el))
+            return "".join(result)
+    else:
+        return res
+
+
+def _findevalitem(obj, base=""):
+    if base.startswith("_"):
+        base = base[1:]
+    el = []
+    for k, v in obj.items():
+        k = k.replace("-", "_")
+        k = k.replace('"', "_")
+        if base and base != "":
+            k = base + "__" + k
+        if isinstance(v, dict):
+            item = _findevalitem(v, k)
+            if item is not None:
+                el.extend(item)
+            continue
+        if isinstance(v, list):
+            el.append("{k}=( {value} )".format(k=k, value=" ".join(v)))
+            continue
+        el.append('{k}="{v}"'.format(k=k, v=v))
+    return el
+
+
+def print_eval(res, search):
+    search = search.replace(".", "_")
+    search = search.replace("-", "_")
+    search = search.replace('"', "")
+    if type(res) == dict:
+        results = _findevalitem(res, search)
+        return ";".join(results)
+    elif type(res) == list:
+        return "{key}=( {value} );".format(key=search, value=" ".join(res))
+    else:
+        return "{search}={value};".format(search=search, value=res)
+
+
+def print_yaml(res):
+    return yaml.dump(res, default_flow_style=False)
+
+
+def print_json(res):
+    return json.dumps(res, indent=4)

--- a/tests/test_niet.py
+++ b/tests/test_niet.py
@@ -1,14 +1,14 @@
 # -*- encoding: utf-8 -*-
 import unittest
 
-import niet
+import niet.output as niet_output
 
 
 class TestPrintFunction(unittest.TestCase):
     def test_squotes(self):
-        output = niet.out_print_squote(['test1', 'test2'])
+        output = niet_output.print_squote(['test1', 'test2'])
         self.assertEqual("'test1' 'test2'", output)
 
     def test_dquotes(self):
-        output = niet.out_print_dquote(['test1', 'test2'])
+        output = niet_output.print_dquote(['test1', 'test2'])
         self.assertEqual('"test1" "test2"', output)


### PR DESCRIPTION
Allow user to eval the output with shell.
All the retrieved elements will become strings that can be transformed
in shell variables by using the linux eval command.

https://github.com/openuado/niet/issues/48
https://gist.github.com/pkuczynski/8665367

Implement #48