### PR TITLE
fix infilename retrieve if input come from stdin

### DIFF
--- a/niet/__init__.py
+++ b/niet/__init__.py
@@ -166,7 +166,7 @@ def main():
         sys.exit(0)
     args = argparser()
     infile = args.file or sys.stdin
-    infilename = args.file.name
+    infilename = args.file.name if args.file else ""
     search = args.object
     dataset = get_data(infile)
     infile.close()


### PR DESCRIPTION
fix infilename retrieve if input come from stdin

```
$ echo '{"one": 1, "two": 2.000000002, "three": 3.3.3}' | niet  .one    
Traceback (most recent call last):
  File "/home/hberaud/.local/share/virtualenvs/niet-R7vGB2rB/bin/niet", line 10, in <module>
    sys.exit(main())
  File "/home/hberaud/dev/perso/niet/niet/__init__.py", line 169, in main
    infilename = args.file.name
AttributeError: 'NoneType' object has no attribute 'name'
```