### PR TITLE
Adding a debug mode to niet

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -138,6 +138,16 @@ $ vim <file-to-edit>
 $ git commit -am 'I did some changes'
 ```
 
+Notice that a debug mode is available and can be easily used during your
+development to dive deep in your execution and observe what happen
+step by step, example:
+
+```
+tox -e venv -- niet --debug \
+    oslo.deliverables\
+    https://raw.githubusercontent.com/openstack/governance/master/reference/projects.yaml
+```
+
 #### Ensure everything work fine
 
 Every following checks are automaticaly executed on pull requests so need to

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ optional arguments:
                         not found
   -v, --version         print the Niet version number and exit (also
                         --version)
+  --debug               Activate the debug mode (based on pdb)
 
 output formats:
   json          Return object in JSON
@@ -694,6 +695,9 @@ You can pass your search with or without quotes like this:
 $ niet project.meta.name your-file.yaml
 $ niet "project.meta.name" your-file.yaml
 ```
+
+You can execute `niet` step by step by using the debug mode. It will allow
+you to inspect your execution during your debug sessions.
 
 ## Contribute
 

--- a/niet/__init__.py
+++ b/niet/__init__.py
@@ -101,6 +101,8 @@ def argparser():
     parser.add_argument('-v', '--version', action='store_true',
                         help="print the Niet version number and \
                         exit (also --version)")
+    parser.add_argument('--debug', action='store_true',
+                        help="Activate the debug mode (based on pdb)")
     return parser.parse_args()
 
 
@@ -186,6 +188,9 @@ def main():
         version()
         sys.exit(0)
     args = argparser()
+    if args.debug:
+        import pdb
+        pdb.set_trace()
     infile = args.file or sys.stdin
     if isinstance(infile, str):
         # NOTE(hberaud): We consider we using a web resource if


### PR DESCRIPTION
This debug mode can be activated at runtime to execute niet step by step.

The niet debug mode is based on python pdb.